### PR TITLE
refactor: 💡 moved cxl policy from price plan to offer level

### DIFF
--- a/src/shared-definitions.yaml
+++ b/src/shared-definitions.yaml
@@ -400,9 +400,6 @@ components:
             quantity:
               type: integer
               example: 2
-        refundability:
-          description: refundability/cancellation policy associated with a given price plan
-          $ref: '#/components/schemas/RefundabilityPolicy'
 
     RefundabilityPolicy:
       description: Accommodation refundability policy in case of booking cancellation
@@ -669,6 +666,9 @@ components:
           $ref: '#/components/schemas/PricePlansReferences'
         convertedPrice:
           $ref: '#/components/schemas/ConvertedPrice'
+        refundability:
+          description: refundability/cancellation policy associated with a given price plan
+          $ref: '#/components/schemas/RefundabilityPolicy'
 
     OfferPriced:
       type: object


### PR DESCRIPTION
to simplify win.so BE and FE cancellation details are better suited in offer level

BREAKING CHANGE: 🧨 refundability attribute no longer exists in pricePlan